### PR TITLE
fix requirement for SCDG

### DIFF
--- a/sema_toolchain/sema_scdg/requirements.txt
+++ b/sema_toolchain/sema_scdg/requirements.txt
@@ -178,5 +178,5 @@ werkzeug==3.0.2
 yara-python==4.5.0
 z3-solver==4.10.2.0
 zipp==3.18.1
-termcolor==2.5.0
+termcolor==2.4.0
 terminal_banner==0.2.0


### PR DESCRIPTION
Fix the requirement file of the SCDG, 
termcolor 2.5 is not supported by Python 3.8