### PR TITLE
SemaSCDG.py fix crash when enabling plugins (hooks, track and IoC)

### DIFF
--- a/sema_toolchain/sema_scdg/application/SemaSCDG.py
+++ b/sema_toolchain/sema_scdg/application/SemaSCDG.py
@@ -472,7 +472,7 @@ class SemaSCDG():
             self.call_sim.custom_hook_windows_symbols(proj)  #TODO ue if (self.is_packed and False) else False,symbs)
 
         if self.hooks_enable:
-            self.plugins.enable_plugin_hooks(self, self.content, state, proj, self.call_sim)
+            self.plugins.enable_plugin_hooks(self.content, state, proj, self.call_sim)
 
     def project_creation(self):
         """Handles project creation and initial analysis setup."""
@@ -538,9 +538,9 @@ class SemaSCDG():
             self.data_manager.get_plugin_data(state, simgr, to_store=self.store_data)
 
         if self.track_command:
-            self.plugins.enable_plugin_commands(self, simgr, self.scdg_graph, exp_dir)
+            self.plugins.enable_plugin_commands(simgr, self.scdg_graph, exp_dir)
         if self.ioc_report:
-            self.plugins.enable_plugin_ioc(self, self.scdg_graph, exp_dir)
+            self.plugins.enable_plugin_ioc(self.scdg_graph, exp_dir)
 
     def run(self, exp_dir):
         """

--- a/sema_toolchain/sema_scdg/application/SemaSCDG.py
+++ b/sema_toolchain/sema_scdg/application/SemaSCDG.py
@@ -121,7 +121,7 @@ class SemaSCDG():
         self.scdg_graph = []
         self.new = {}
         self.nameFileShort = ""
-        self.content = ""
+        self.content = b""
 
         self.plugins = PluginManager()
         self.packing_manager = self.plugins.get_plugin_packing()


### PR DESCRIPTION
When enabling the plugins:
- `plugin_track_command = true`
- `plugin_ioc_report = true`
- `plugin_hooks = true`

SemaSCDG.py crashes with error messages such as:
```python
  File ".../sema_scdg/application/SemaSCDG.py", line 543, in collect_data
    self.plugins.enable_plugin_ioc(self, self.scdg_graph, exp_dir)
TypeError: PluginManager.enable_plugin_ioc() takes 3 positional arguments but 4 were given
```
Because an additional `self` argument is passed to the functions `PluginManager.enable_plugin_[hooks - commands - ioc]`.

This pull request removes the additional arguments causing the crashes.