### PR TITLE
SemaSCDG.py crashes when enabling plugin_hook

### DIFF
--- a/sema_toolchain/sema_scdg/application/SemaSCDG.py
+++ b/sema_toolchain/sema_scdg/application/SemaSCDG.py
@@ -472,7 +472,7 @@ class SemaSCDG():
             self.call_sim.custom_hook_windows_symbols(proj)  #TODO ue if (self.is_packed and False) else False,symbs)
 
         if self.hooks_enable:
-            self.plugins.enable_plugin_hooks(self, self.content, state, proj, self.call_sim)
+            self.plugins.enable_plugin_hooks(self.content, state, proj, self.call_sim)
 
     def project_creation(self):
         """Handles project creation and initial analysis setup."""
@@ -538,9 +538,9 @@ class SemaSCDG():
             self.data_manager.get_plugin_data(state, simgr, to_store=self.store_data)
 
         if self.track_command:
-            self.plugins.enable_plugin_commands(self, simgr, self.scdg_graph, exp_dir)
+            self.plugins.enable_plugin_commands(simgr, self.scdg_graph, exp_dir)
         if self.ioc_report:
-            self.plugins.enable_plugin_ioc(self, self.scdg_graph, exp_dir)
+            self.plugins.enable_plugin_ioc(self.scdg_graph, exp_dir)
 
     def run(self, exp_dir):
         """

--- a/sema_toolchain/sema_scdg/application/SemaSCDG.py
+++ b/sema_toolchain/sema_scdg/application/SemaSCDG.py
@@ -121,7 +121,7 @@ class SemaSCDG():
         self.scdg_graph = []
         self.new = {}
         self.nameFileShort = ""
-        self.content = ""
+        self.content = b""
 
         self.plugins = PluginManager()
         self.packing_manager = self.plugins.get_plugin_packing()

--- a/sema_toolchain/sema_scdg/application/SemaSCDG.py
+++ b/sema_toolchain/sema_scdg/application/SemaSCDG.py
@@ -121,7 +121,7 @@ class SemaSCDG():
         self.scdg_graph = []
         self.new = {}
         self.nameFileShort = ""
-        self.content = b""
+        self.content = ""
 
         self.plugins = PluginManager()
         self.packing_manager = self.plugins.get_plugin_packing()

--- a/sema_toolchain/sema_scdg/application/SemaSCDG.py
+++ b/sema_toolchain/sema_scdg/application/SemaSCDG.py
@@ -121,7 +121,7 @@ class SemaSCDG():
         self.scdg_graph = []
         self.new = {}
         self.nameFileShort = ""
-        self.content = ""
+        self.content = b""
 
         self.plugins = PluginManager()
         self.packing_manager = self.plugins.get_plugin_packing()
@@ -472,7 +472,7 @@ class SemaSCDG():
             self.call_sim.custom_hook_windows_symbols(proj)  #TODO ue if (self.is_packed and False) else False,symbs)
 
         if self.hooks_enable:
-            self.plugins.enable_plugin_hooks(self.content, state, proj, self.call_sim)
+            self.plugins.enable_plugin_hooks(self, self.content, state, proj, self.call_sim)
 
     def project_creation(self):
         """Handles project creation and initial analysis setup."""
@@ -538,9 +538,9 @@ class SemaSCDG():
             self.data_manager.get_plugin_data(state, simgr, to_store=self.store_data)
 
         if self.track_command:
-            self.plugins.enable_plugin_commands(simgr, self.scdg_graph, exp_dir)
+            self.plugins.enable_plugin_commands(self, simgr, self.scdg_graph, exp_dir)
         if self.ioc_report:
-            self.plugins.enable_plugin_ioc(self.scdg_graph, exp_dir)
+            self.plugins.enable_plugin_ioc(self, self.scdg_graph, exp_dir)
 
     def run(self, exp_dir):
         """

--- a/sema_toolchain/sema_scdg/application/SemaSCDG.py
+++ b/sema_toolchain/sema_scdg/application/SemaSCDG.py
@@ -472,7 +472,7 @@ class SemaSCDG():
             self.call_sim.custom_hook_windows_symbols(proj)  #TODO ue if (self.is_packed and False) else False,symbs)
 
         if self.hooks_enable:
-            self.plugins.enable_plugin_hooks(self, self.content, state, proj, self.call_sim)
+            self.plugins.enable_plugin_hooks(self.content, state, proj, self.call_sim)
 
     def project_creation(self):
         """Handles project creation and initial analysis setup."""


### PR DESCRIPTION
(this fix includes part of the [Pull request#42](https://github.com/csvl/SEMA/pull/42) for being able to enable the plugin-hook)

When enabling plugin_hooks, the parameter `self.content` passed to PluginHook.py is of type `str`, where it is expected to be `bytes`.

```python
  File ".../sema_scdg/application/SemaSCDG.py", line 475, in setup_hooks
    self.plugins.enable_plugin_hooks(self.content, state, proj, self.call_sim)
  File ".../sema_scdg/application/plugin/PluginManager.py", line 53, in enable_plugin_hooks
    self.hooks.initialization(content, is_64bits=proj.arch.name == "AMD64")
  File ".../sema_scdg/application/plugin/PluginHooks.py", line 59, in initialization
    pe_header = int.from_bytes(cont[0x3c:0x40],"little")
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: cannot convert 'str' object to bytes
```

The proposed fix initializes SemaSCDG's `self.content` property as a byte string.