### PR TITLE
Fix wstring argument type definitions in SyscallToSCDG

### DIFF
--- a/sema_toolchain/sema_scdg/application/helper/SyscallToSCDG.py
+++ b/sema_toolchain/sema_scdg/application/helper/SyscallToSCDG.py
@@ -402,6 +402,8 @@ class SyscallToSCDG:
             ("LPCWSTR" in callee_arg[i]["type"]
             or "LPWSTR" in callee_arg[i]["type"]
             or "wchar_t*const" in callee_arg[i]["type"]
+            or "const wchar_t*" in callee_arg[i]["type"]
+            or "wchar_t*" in callee_arg[i]["type"]
             or "OLECHAR" in callee_arg[i]["type"]
             or "PWSTR" in callee_arg[i]["type"]
             or "PCWSTR" in callee_arg[i]["type"]


### PR DESCRIPTION
This pull request adds type definitions which enable the SyscallToSCDG module to recognize wide string parameters used in syscalls such as [`_wcsicmp`](https://learn.microsoft.com/en-us/cpp/c-runtime-library/reference/stricmp-wcsicmp-mbsicmp-stricmp-l-wcsicmp-l-mbsicmp-l?view=msvc-170).

Without such type definition, arguments appear as unsigned integers (pointers) in the SCDG.
With them, the module tries (and succeed as far as my tests went) to resolve the wide strings and put the result in the SCDG.